### PR TITLE
Added initial version of CI to rebuild dependencies package

### DIFF
--- a/.github/workflows/rebuildDependencies.yml
+++ b/.github/workflows/rebuildDependencies.yml
@@ -1,0 +1,109 @@
+name: VCMI - dependencies
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: mac-intel
+            os: macos-13
+            preset: macos-conan-ninja-release
+            conan_profile: macos-intel
+            conan_options: --options with_apple_system_libs=True
+            artifact_platform: intel
+          - platform: mac-arm
+            os: macos-13
+            preset: macos-arm-conan-ninja-release
+            conan_profile: macos-arm
+            conan_options: --options with_apple_system_libs=True
+            artifact_platform: arm
+          - platform: ios
+            os: macos-13
+            preset: ios-release-conan-ccache
+            conan_profile: ios-arm64
+            conan_options: --options with_apple_system_libs=True
+          - platform: mingw
+            os: ubuntu-22.04
+            preset: windows-mingw-conan-linux
+            conan_profile: mingw64-linux.jinja
+          - platform: mingw-32
+            os: ubuntu-22.04
+            preset: windows-mingw-conan-linux
+            conan_profile: mingw32-linux.jinja
+          - platform: android-32
+            os: macos-14
+            preset: android-conan-ninja-release
+            conan_profile: android-32-ndk
+            conan_options: --conf tools.android:ndk_path=$ANDROID_NDK_ROOT
+            artifact_platform: armeabi-v7a
+          - platform: android-64
+            os: macos-14
+            preset: android-conan-ninja-release
+            conan_profile: android-64-ndk
+            conan_options: --conf tools.android:ndk_path=$ANDROID_NDK_ROOT
+            artifact_platform: arm64-v8a
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        repository: 'vcmi/vcmi'
+        ref: 'update_prebuilts'
+
+    - name: Install dependencies
+      run: source '${{github.workspace}}/CI/${{matrix.platform}}/before_install.sh'
+      env:
+        VCMI_BUILD_PLATFORM: x64
+
+    - name: Remove old packages
+      run: rm -rf ~/.conan/data/ffmpeg ~/.conan/data/yasm ~/.conan/data/pkgconfig ~/.conan/data/xz_utils
+
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+
+    - name: Setup Conan
+      run: pip3 install 'conan<2.0'
+
+    - name: Generate conan profile
+      run: |
+        conan profile new default --detect
+        conan install . \
+          --install-folder=conan-generated \
+          --no-imports \
+          --build=missing \
+          --profile:build=default \
+          --profile:host=CI/conan/${{ matrix.conan_profile }} \
+          ${{ matrix.conan_options }}
+      env:
+        GENERATE_ONLY_BUILT_CONFIG: 1
+
+    - name: Remove builds and source code
+      run: "conan remove --builds --src --force '*'"
+      
+    - name: Remove Android SDK
+      if: ${{ startsWith(matrix.platform, 'android') }}
+      run: rm -rf ~/.conan/data/android-ndk
+
+    - name: Create dependencies archive
+      run: "tar --create --xz --file dependencies-${{matrix.platform}}.txz -C ~/.conan data"
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: dependencies-${{ matrix.platform }}
+        compression-level: 0
+        path: 'dependencies-${{matrix.platform}}.txz'


### PR DESCRIPTION
Continuation of https://github.com/vcmi/vcmi/pull/4461

Trying to establish flow for update of conan-built dependencies (so all other than msvc which uses vcpkg).

Currently planning following flow:
- if needed, update conanfile in vcmi/vcmi repo (in a separate branch). Right now I am using branch 'update_prebuilts' for that.
- run workflow added by this PR to generate prebuilts packages
- download artifacts & reupload them as release in this repository
- create PR in vcmi/vcmi repo with updated links for prebuilts downloads

Not sure about 1st step. We need new version of conanfile as well as few files from vcmi/vcmi repo, however it feels weird to create branch that would only be used in another repo. But haven't found better approaches.

TODO's for future:
- rebuild entire package (and not only ffmpeg, like in this PR). Both to test recipes and to replace any binaries that were built locally by devs with binaries built in clean CI environment.
- automatically create release (probably only for manually triggered workflows), to remove need of manual download & reupload of packages
- run workflow on schedule (daily? weekly?), so if upstream recipe has breaking change it will be detected by us.
- build Android package on Linux CI (and use Linux CI for android packages on vcmi/vcmi)
- add documentation on how to use this repository in place of currently empty Readme.md
- once vcmi/vcmi uses only dependencies from this repo, archive all other repositories with dependencies (other than vcpkg)