### PR TITLE
Workflow improvements

### DIFF
--- a/.github/workflows/rebuildDependencies.yml
+++ b/.github/workflows/rebuildDependencies.yml
@@ -16,50 +16,39 @@ jobs:
           - platform: mac-intel
             os: macos-13
             before_install: macos.sh
-            preset: macos-conan-ninja-release
             conan_profile: macos-intel
             conan_prebuilts: dependencies-mac-intel
             conan_options: --options with_apple_system_libs=True
-            artifact_platform: intel
           - platform: mac-arm
             os: macos-13
             before_install: macos.sh
-            preset: macos-arm-conan-ninja-release
             conan_profile: macos-arm
             conan_prebuilts: dependencies-mac-arm
             conan_options: --options with_apple_system_libs=True
-            artifact_platform: arm
           - platform: ios
             os: macos-13
             before_install: macos.sh
-            preset: ios-release-conan-ccache
             conan_profile: ios-arm64
             conan_prebuilts: dependencies-ios
             conan_options: --options with_apple_system_libs=True
           - platform: mingw-x86-64
             os: ubuntu-24.04
             before_install: mingw_x86_64.sh
-            preset: windows-mingw-conan-linux
             conan_profile: mingw64-linux.jinja
             conan_prebuilts: dependencies-mingw
           - platform: mingw-x86
             os: ubuntu-24.04
             before_install: mingw_x86.sh
-            preset: windows-mingw-conan-linux
             conan_profile: mingw32-linux.jinja
             conan_prebuilts: dependencies-mingw-32
           - platform: android-armeabi-v7a
             os: ubuntu-24.04
-            preset: android-conan-ninja-release
             conan_profile: android-32-ndk
             conan_prebuilts: dependencies-android-32
-            artifact_platform: armeabi-v7a
           - platform: android-arm64-v8a
             os: ubuntu-24.04
-            preset: android-conan-ninja-release
             conan_profile: android-64-ndk
             conan_prebuilts: dependencies-android-64
-            artifact_platform: arm64-v8a
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -86,12 +75,12 @@ jobs:
       if: "${{ matrix.conan_prebuilts != '' }}"
       run: source '${{github.workspace}}/CI/install_conan_dependencies.sh' '${{matrix.conan_prebuilts}}'
 
-    - name: Remove old binary packages
+    - name: Remove old binary packages (non-android)
       if: ${{ !startsWith(matrix.platform, 'android') }}
       run: rm -rf ~/.conan/data/*/*/_/_/package
     
     # TODO: fix libiconv - fails to build on android (both macos and linux host)
-    - name: Remove old binary packages
+    - name: Remove old binary packages (android)
       if: ${{ startsWith(matrix.platform, 'android') }}
       run: |
         mv ~/.conan/data/libiconv ~/
@@ -103,7 +92,6 @@ jobs:
     - name: Remove old recipes
       run: |
         rm -rf ~/.conan/data/ffmpeg 
-        rm -rf ~/.conan/data/pkgconfig
         rm -rf ~/.conan/data/xz_utils
         rm -rf ~/.conan/data/sdl_mixer
         rm -rf ~/.conan/data/sdl_image

--- a/.github/workflows/rebuildDependencies.yml
+++ b/.github/workflows/rebuildDependencies.yml
@@ -33,12 +33,12 @@ jobs:
             conan_options: --options with_apple_system_libs=True
           - platform: mingw-x86-64
             os: ubuntu-24.04
-            before_install: mingw_x86_64.sh
+            before_install: mingw.sh
             conan_profile: mingw64-linux.jinja
             conan_prebuilts: dependencies-mingw-x86-64
           - platform: mingw-x86
             os: ubuntu-24.04
-            before_install: mingw_x86.sh
+            before_install: mingw.sh
             conan_profile: mingw32-linux.jinja
             conan_prebuilts: dependencies-mingw-x86
           - platform: android-armeabi-v7a

--- a/.github/workflows/rebuildDependencies.yml
+++ b/.github/workflows/rebuildDependencies.yml
@@ -83,8 +83,34 @@ jobs:
       if: "${{ matrix.conan_prebuilts != '' }}"
       run: source '${{github.workspace}}/CI/install_conan_dependencies.sh' '${{matrix.conan_prebuilts}}'
 
-    - name: Remove old packages
-      run: rm -rf ~/.conan/data/ffmpeg ~/.conan/data/yasm ~/.conan/data/pkgconfig ~/.conan/data/xz_utils
+    - name: Remove old binary packages
+      if: ${{ !startsWith(matrix.platform, 'android') }}
+      run: rm -rf ~/.conan/data/*/*/_/_/package
+    
+    # TODO: fix libiconv - fails to build on android (both macos and linux host)
+    - name: Remove old binary packages
+      if: ${{ startsWith(matrix.platform, 'android') }}
+      run: |
+        mv ~/.conan/data/libiconv ~/
+        rm -rf ~/.conan/data/*/*/_/_/package
+        mv ~/libiconv ~/.conan/data
+
+    # Completely remove packages that were confirmed to be rebuildable using upstream recipe/sources
+    # TODO: generate entire package from scratch instead of such cleanup
+    - name: Remove old recipes
+      run: |
+        rm -rf ~/.conan/data/ffmpeg 
+        rm -rf ~/.conan/data/pkgconfig
+        rm -rf ~/.conan/data/xz_utils
+        rm -rf ~/.conan/data/sdl_mixer
+        rm -rf ~/.conan/data/sdl_image
+        rm -rf ~/.conan/data/sdl_ttf 
+        rm -rf ~/.conan/data/sdl
+      
+    - name: Remove old recipes (non-apple)
+      if: ${{ matrix.platform != 'ios' && matrix.platform != 'mac-intel' && matrix.platform != 'mac-arm' }}
+      run: |
+        rm -rf ~/.conan/data/sqlite3
 
     - name: Setup Python
       uses: actions/setup-python@v5

--- a/.github/workflows/rebuildDependencies.yml
+++ b/.github/workflows/rebuildDependencies.yml
@@ -35,20 +35,20 @@ jobs:
             os: ubuntu-24.04
             before_install: mingw_x86_64.sh
             conan_profile: mingw64-linux.jinja
-            conan_prebuilts: dependencies-mingw
+            conan_prebuilts: dependencies-mingw-x86-64
           - platform: mingw-x86
             os: ubuntu-24.04
             before_install: mingw_x86.sh
             conan_profile: mingw32-linux.jinja
-            conan_prebuilts: dependencies-mingw-32
+            conan_prebuilts: dependencies-mingw-x86
           - platform: android-armeabi-v7a
             os: ubuntu-24.04
             conan_profile: android-32-ndk
-            conan_prebuilts: dependencies-android-32
+            conan_prebuilts: dependencies-android-armeabi-v7a
           - platform: android-arm64-v8a
             os: ubuntu-24.04
             conan_profile: android-64-ndk
-            conan_prebuilts: dependencies-android-64
+            conan_prebuilts: dependencies-android-arm64-v8a
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/rebuildDependencies.yml
+++ b/.github/workflows/rebuildDependencies.yml
@@ -17,37 +17,44 @@ jobs:
             os: macos-13
             preset: macos-conan-ninja-release
             conan_profile: macos-intel
+            conan_prebuilts: dependencies-mac-intel
             conan_options: --options with_apple_system_libs=True
             artifact_platform: intel
           - platform: mac-arm
             os: macos-13
             preset: macos-arm-conan-ninja-release
             conan_profile: macos-arm
+            conan_prebuilts: dependencies-mac-arm
             conan_options: --options with_apple_system_libs=True
             artifact_platform: arm
           - platform: ios
             os: macos-13
             preset: ios-release-conan-ccache
             conan_profile: ios-arm64
+            conan_prebuilts: dependencies-ios
             conan_options: --options with_apple_system_libs=True
           - platform: mingw
             os: ubuntu-24.04
             preset: windows-mingw-conan-linux
             conan_profile: mingw64-linux.jinja
+            conan_prebuilts: dependencies-mingw
           - platform: mingw-32
             os: ubuntu-24.04
             preset: windows-mingw-conan-linux
             conan_profile: mingw32-linux.jinja
+            conan_prebuilts: dependencies-mingw-32
           - platform: android-32
             os: macos-14
             preset: android-conan-ninja-release
             conan_profile: android-32-ndk
+            conan_prebuilts: dependencies-android-32
             conan_options: --conf tools.android:ndk_path=$ANDROID_NDK_ROOT
             artifact_platform: armeabi-v7a
           - platform: android-64
             os: macos-14
             preset: android-conan-ninja-release
             conan_profile: android-64-ndk
+            conan_prebuilts: dependencies-android-64
             conan_options: --conf tools.android:ndk_path=$ANDROID_NDK_ROOT
             artifact_platform: arm64-v8a
     runs-on: ${{ matrix.os }}
@@ -68,10 +75,13 @@ jobs:
         distribution: 'temurin'
         java-version: '11'
 
-    - name: Install dependencies
+    - name: Prepare CI
+      if: ${{ !startsWith(matrix.platform, 'android-linux') }}
       run: source '${{github.workspace}}/CI/${{matrix.platform}}/before_install.sh'
-      env:
-        VCMI_BUILD_PLATFORM: x64
+
+    - name: Install Conan Dependencies
+      if: "${{ matrix.conan_prebuilts != '' }}"
+      run: source '${{github.workspace}}/CI/install_conan_dependencies.sh' '${{matrix.conan_prebuilts}}'
 
     - name: Remove old packages
       run: rm -rf ~/.conan/data/ffmpeg ~/.conan/data/yasm ~/.conan/data/pkgconfig ~/.conan/data/xz_utils

--- a/.github/workflows/rebuildDependencies.yml
+++ b/.github/workflows/rebuildDependencies.yml
@@ -31,11 +31,11 @@ jobs:
             conan_profile: ios-arm64
             conan_options: --options with_apple_system_libs=True
           - platform: mingw
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             preset: windows-mingw-conan-linux
             conan_profile: mingw64-linux.jinja
           - platform: mingw-32
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             preset: windows-mingw-conan-linux
             conan_profile: mingw32-linux.jinja
           - platform: android-32

--- a/.github/workflows/rebuildDependencies.yml
+++ b/.github/workflows/rebuildDependencies.yml
@@ -15,6 +15,7 @@ jobs:
         include:
           - platform: mac-intel
             os: macos-13
+            before_install: macos.sh
             preset: macos-conan-ninja-release
             conan_profile: macos-intel
             conan_prebuilts: dependencies-mac-intel
@@ -22,6 +23,7 @@ jobs:
             artifact_platform: intel
           - platform: mac-arm
             os: macos-13
+            before_install: macos.sh
             preset: macos-arm-conan-ninja-release
             conan_profile: macos-arm
             conan_prebuilts: dependencies-mac-arm
@@ -29,27 +31,30 @@ jobs:
             artifact_platform: arm
           - platform: ios
             os: macos-13
+            before_install: macos.sh
             preset: ios-release-conan-ccache
             conan_profile: ios-arm64
             conan_prebuilts: dependencies-ios
             conan_options: --options with_apple_system_libs=True
-          - platform: mingw
+          - platform: mingw-x86-64
             os: ubuntu-24.04
+            before_install: mingw_x86_64.sh
             preset: windows-mingw-conan-linux
             conan_profile: mingw64-linux.jinja
             conan_prebuilts: dependencies-mingw
-          - platform: mingw-32
+          - platform: mingw-x86
             os: ubuntu-24.04
+            before_install: mingw_x86.sh
             preset: windows-mingw-conan-linux
             conan_profile: mingw32-linux.jinja
             conan_prebuilts: dependencies-mingw-32
-          - platform: android-32
+          - platform: android-armeabi-v7a
             os: ubuntu-24.04
             preset: android-conan-ninja-release
             conan_profile: android-32-ndk
             conan_prebuilts: dependencies-android-32
             artifact_platform: armeabi-v7a
-          - platform: android-64
+          - platform: android-arm64-v8a
             os: ubuntu-24.04
             preset: android-conan-ninja-release
             conan_profile: android-64-ndk
@@ -74,8 +79,8 @@ jobs:
         java-version: '11'
 
     - name: Prepare CI
-      if: ${{ !startsWith(matrix.platform, 'android') }}
-      run: source '${{github.workspace}}/CI/${{matrix.platform}}/before_install.sh'
+      if: "${{ matrix.before_install != '' }}"
+      run: source '${{github.workspace}}/CI/before_install/${{matrix.before_install}}'
 
     - name: Install Conan Dependencies
       if: "${{ matrix.conan_prebuilts != '' }}"

--- a/.github/workflows/rebuildDependencies.yml
+++ b/.github/workflows/rebuildDependencies.yml
@@ -136,9 +136,18 @@ jobs:
     - name: Remove builds and source code
       run: "conan remove --builds --src --force '*'"
       
-    - name: Remove Android SDK
-      if: ${{ startsWith(matrix.platform, 'android') }}
-      run: rm -rf ~/.conan/data/android-ndk
+    - name: Remove build requirements
+      run: |
+        rm -rf ~/.conan/data/android-ndk
+        rm -rf ~/.conan/data/autoconf
+        rm -rf ~/.conan/data/automake
+        rm -rf ~/.conan/data/b2
+        rm -rf ~/.conan/data/cmake
+        rm -rf ~/.conan/data/gnu-config
+        rm -rf ~/.conan/data/libtool
+        rm -rf ~/.conan/data/m4
+        rm -rf ~/.conan/data/pkgconf
+        rm -rf ~/.conan/data/yasm
 
     - name: Create dependencies archive
       run: "tar --create --xz --file dependencies-${{matrix.platform}}.txz -C ~/.conan data"

--- a/.github/workflows/rebuildDependencies.yml
+++ b/.github/workflows/rebuildDependencies.yml
@@ -44,18 +44,16 @@ jobs:
             conan_profile: mingw32-linux.jinja
             conan_prebuilts: dependencies-mingw-32
           - platform: android-32
-            os: macos-14
+            os: ubuntu-24.04
             preset: android-conan-ninja-release
             conan_profile: android-32-ndk
             conan_prebuilts: dependencies-android-32
-            conan_options: --conf tools.android:ndk_path=$ANDROID_NDK_ROOT
             artifact_platform: armeabi-v7a
           - platform: android-64
-            os: macos-14
+            os: ubuntu-24.04
             preset: android-conan-ninja-release
             conan_profile: android-64-ndk
             conan_prebuilts: dependencies-android-64
-            conan_options: --conf tools.android:ndk_path=$ANDROID_NDK_ROOT
             artifact_platform: arm64-v8a
     runs-on: ${{ matrix.os }}
     defaults:
@@ -76,7 +74,7 @@ jobs:
         java-version: '11'
 
     - name: Prepare CI
-      if: ${{ !startsWith(matrix.platform, 'android-linux') }}
+      if: ${{ !startsWith(matrix.platform, 'android') }}
       run: source '${{github.workspace}}/CI/${{matrix.platform}}/before_install.sh'
 
     - name: Install Conan Dependencies

--- a/.github/workflows/rebuildDependencies.yml
+++ b/.github/workflows/rebuildDependencies.yml
@@ -104,13 +104,8 @@ jobs:
       run: |
         rm -rf ~/.conan/data/sqlite3
 
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.10'
-
-    - name: Setup Conan
-      run: pip3 install 'conan<2.0'
+    - name: Install Conan
+      run: pipx install 'conan<2.0'
 
     - name: Generate conan profile
       run: |

--- a/.github/workflows/rebuildDependencies.yml
+++ b/.github/workflows/rebuildDependencies.yml
@@ -62,6 +62,12 @@ jobs:
         repository: 'vcmi/vcmi'
         ref: 'update_prebuilts'
 
+    - uses: actions/setup-java@v4
+      if: ${{ startsWith(matrix.platform, 'android') }}
+      with:
+        distribution: 'temurin'
+        java-version: '11'
+
     - name: Install dependencies
       run: source '${{github.workspace}}/CI/${{matrix.platform}}/before_install.sh'
       env:

--- a/.github/workflows/rebuildDependencies.yml
+++ b/.github/workflows/rebuildDependencies.yml
@@ -149,6 +149,7 @@ jobs:
         rm -rf ~/.conan/data/gnu-config
         rm -rf ~/.conan/data/libtool
         rm -rf ~/.conan/data/m4
+        rm -rf ~/.conan/data/nasm
         rm -rf ~/.conan/data/pkgconf
         rm -rf ~/.conan/data/yasm
 

--- a/.github/workflows/rebuildDependencies.yml
+++ b/.github/workflows/rebuildDependencies.yml
@@ -91,11 +91,12 @@ jobs:
     # TODO: generate entire package from scratch instead of such cleanup
     - name: Remove old recipes
       run: |
-        rm -rf ~/.conan/data/ffmpeg 
+        rm -rf ~/.conan/data/boost
+        rm -rf ~/.conan/data/ffmpeg
         rm -rf ~/.conan/data/xz_utils
         rm -rf ~/.conan/data/sdl_mixer
         rm -rf ~/.conan/data/sdl_image
-        rm -rf ~/.conan/data/sdl_ttf 
+        rm -rf ~/.conan/data/sdl_ttf
         rm -rf ~/.conan/data/sdl
       
     - name: Remove old recipes (non-apple)

--- a/README.md
+++ b/README.md
@@ -22,21 +22,13 @@ Current flow to update dependencies:
   - ffmpeg fails to find its dependencies when building with conan 1 + msvc 2019. Might be fixed in conan 2.
   - Qt fails to build due to broken string escaping in a path (conan 1 + msvc 2019)
 
-- Switch Android CI to use Linux runners instead of macOS runners (both for prebuilts and for vcmi itself)
+- Rebuild SDL_mixer and try to enable support for opus and flac. Needs investigation as to why libopus / libflac fail to build
 
-- Upgrade ubuntu runner to ubuntu-24.04 and rebuild packages using newer mingw
-
-- Rebuild boost and disable boost_url which we don't use
-
-- Rebuild SDL (including SDL_mixer and SDL_image). 
-  - Consider updating packages.
-  - Enable support for opus and flac.
-  - Remove unnecessary image formats such as gif and pcx
-  - Ensure that vcmi can load ogg/opus and flac as 'sounds' and not only as music
+- Consider removing pcx support from SDL_image
 
 - Rebuild ffmpeg with libdav1d and av1 support enabled. Needs investigation as to why dav1d fails to build on mingw and on android.
 
-- Rebuild all binaries in prebuilts package to ensure that everything is configured correctly and to replace any locally-built binaries with binaries from CI
+- Find out why libiconv fails to rebuild on Android
 
 - Rebuild entire package from scratch using latest recipes from conan, to test current version of recipes
 


### PR DESCRIPTION
Trying to implement some of the todo's mentioned in PR #2

List of changes
- Conan dependencies installation is now a separate step in CI, package name is now defined as parameter in matrix
- Before install script is now defined as parameter in matrix, to remove identical files
- Renamed platforms names to use form (OS-architecture)
- All binaries have been rebuilt on CI (with exception of libiconv on Android which fails due to weird bug)
- Switched mingw CI from ubuntu 22.04 to ubuntu 24.04 and removed previously required workarounds
- Switched Android CI from macos to ubuntu to reduce number of macos CI runners
- Disabled building of boost_url since it is not used by vcmi
- Updated SDL packages with all its components, updated settings of SDL_image and SDL_mixer to match upstream changes
- Added removal of all build tools, like cmake in addition to android SDK to reduce size of output package