### PR TITLE
add workflow to create release from a given Actions run

### DIFF
--- a/.github/workflows/rebuildDependencies.yml
+++ b/.github/workflows/rebuildDependencies.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths-ignore:
       - README.md
+      - .github/workflows/releaseFromRun.yml
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/releaseFromRun.yml
+++ b/.github/workflows/releaseFromRun.yml
@@ -1,0 +1,54 @@
+name: Create release from Actions run
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'Actions run ID which to get artifacts from'
+        required: true
+        type: number
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      LISTS_DIR: lists
+      DEPENDENCIES_DIR: deps
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Download artifacts
+        run: |
+          gh run download ${{ github.event.inputs.run_id }} \
+            --repo ${{ github.repository }} \
+            --dir "$LISTS_DIR" \
+            --pattern "list of*"
+          gh run download ${{ github.event.inputs.run_id }} \
+            --repo ${{ github.repository }} \
+            --dir "$DEPENDENCIES_DIR" \
+            --pattern "dependencies-*"
+
+      - name: Create release
+        shell: python
+        run: |
+          from datetime import date
+          from glob import glob
+          from os import getenv
+          from pathlib import Path
+          from subprocess import run
+
+          releaseNotes = "Generated from [this](https://github.com/${{ github.repository }}/actions/runs/${{ github.event.inputs.run_id }}) Actions run"
+          for packageListPath in sorted(Path(".").glob(f"{getenv("LISTS_DIR")}/**/*.txt")):
+              releaseNotes += f"""
+
+          <details><summary><b>{packageListPath.stem.removeprefix("dependencies-")}</b> packages</summary>
+
+          {open(packageListPath, "r").read()}
+          </details>"""
+
+          tag = str(date.today())
+          dependencies = glob(f"{getenv("DEPENDENCIES_DIR")}/**/*.tgz")
+          run([
+              "gh", "release", "create", tag,
+              "--repo", "${{ github.repository }}",
+              "--prerelease",
+              "--title", tag,
+              "--notes", releaseNotes,
+          ] + dependencies, check=True)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Current flow to update dependencies:
 1. Open PR with changes
 2. Make sure that CI build succeeds
 3. Merge the PR
-4. (TBD) Run workflow to create new release from the CI run
+4. Run workflow to create new release from the CI run
 5. (TBD) Update dependencies submodule and prebuilts URL in VCMI repo to point to the new commit / release, update VCMI code if needed
 
 # TODO List
@@ -19,5 +19,3 @@ Current flow to update dependencies:
 - Rebuild ffmpeg with libdav1d and av1 support enabled. Needs investigation as to why dav1d fails to build on mingw and on android.
 
 - Run CI with full package rebuild on schedule (weekly? monthly?) to detect any regressions or breaking changes in CI or in used recipes
-
-- (shouldn't be needed probably) Automatically generate Github release with updated packages as part of CI. Should probably be done only for changes in main branch and/or for manually triggered workflows


### PR DESCRIPTION
What it does:
1. downloads all artifacts from the given run as 2 groups: dependencies and text files that contain list of packages
2. forms release notes using the text files
3. creates GitHub release with the dependencies with tag/title YYYY-MM-DD

Example: https://github.com/kambala-decapitator/workflow-test/releases/tag/untagged-9c1f1c05e067610f5fd2 (created draft and uploaded text files instead of actual dependencies intentionally)