### PR TITLE
Qt5 fixes

### DIFF
--- a/.github/workflows/rebuildDependencies.yml
+++ b/.github/workflows/rebuildDependencies.yml
@@ -140,7 +140,7 @@ jobs:
 
         # versions must be synced with: conan_patches/<package>/conandata.yml
         # if no custom patches are required for a package, it should be removed from here
-        for p in minizip/1.3.1 flac/1.4.2 qt/5.15.16 ; do
+        for p in minizip/1.3.1 flac/1.4.2 ; do
           IFS_OLD="$IFS"
           IFS=/
           read package version <<<"$p"
@@ -163,11 +163,12 @@ jobs:
         done
 
     # TODO: remove LuaJIT when https://github.com/conan-io/conan-center-index/pull/26577 is merged
-    - name: Build LuaJIT from PR changes
-      if: ${{ !contains(matrix.conan_options, '"&:lua_lib=lua"') }}
+    # TODO: remove Qt5 when https://github.com/conan-io/conan-center-index/pull/28251 is merged
+    - name: Build LuaJIT & Qt5 from PR changes
       run: |
         cciForkRepo='cci-fork'
         branchName='vcmi'
+        recipePathQt='recipes/qt'
 
         git clone "https://github.com/kambala-decapitator/conan-center-index.git" "$cciForkRepo" \
           --branch "$branchName" \
@@ -179,20 +180,30 @@ jobs:
         cd "$cciForkRepo"
         git sparse-checkout set \
           recipes/luajit \
+          $recipePathQt \
 
         git checkout
 
-        for p in luajit/2.1.0-beta3 ; do
+        for p in ${{ contains(matrix.conan_options, '"&:lua_lib=lua"') && ' ' || 'luajit/2.1.0-beta3' }} qt/5.15.16 ; do
           IFS_OLD="$IFS"
           IFS=/
           read package version <<<"$p"
           IFS="$IFS_OLD"
 
-          conan create "recipes/$package/all" \
+          if [[ $package == qt ]] ; then
+            packagePath="$recipePathQt/5.x.x"
+          else
+            packagePath="recipes/$package/all"
+          fi
+
+          # Windows workaround for https://bugreports.qt.io/browse/QTBUG-84543
+          PATH="$WINDOWS_PERL_DIR:$PATH" conan create "$packagePath" \
             --version=$version \
             $CONAN_PROFILES \
             --build=missing \
-            --test-folder=
+            --test-folder= \
+            --core-conf core.sources.patch:extra_path=$CUSTOM_PATCHES_PATH \
+            ${{ startsWith(matrix.platform, 'android') && '-o "qt/*:android_sdk=$ANDROID_HOME"' || '' }}
         done
 
     - name: Generate conan profile

--- a/.github/workflows/rebuildDependencies.yml
+++ b/.github/workflows/rebuildDependencies.yml
@@ -206,7 +206,7 @@ jobs:
             ${{ startsWith(matrix.platform, 'android') && '-o "qt/*:android_sdk=$ANDROID_HOME"' || '' }}
         done
 
-    - name: Generate conan profile
+    - name: Build the rest of the dependencies
       run: |
         conan install . \
           --output-folder=conan-generated \

--- a/conan_patches/qt/conandata.yml
+++ b/conan_patches/qt/conandata.yml
@@ -1,6 +1,10 @@
 patches:
   "5.15.16":
     - "base_path": "qt5/qtbase"
+      "patch_file": "patches/android-19-jar.diff"
+    - "base_path": "qt5/qtbase"
+      "patch_file": "patches/android-19-java.diff"
+    - "base_path": "qt5/qtbase"
       "patch_file": "patches/android-21-22.diff"
     - "base_path": "qt5/qtbase"
       "patch_file": "patches/xiaomi.diff"

--- a/conan_patches/qt/patches/_kde.md
+++ b/conan_patches/qt/patches/_kde.md
@@ -1,0 +1,5 @@
+Patches from [KDE project](https://community.kde.org/Qt5PatchCollection) were generated from a72077a88903fe532f6a749677eb4da4ea99f79f, but a few had to be dropped because Conan can't apply them, namely:
+
+- 0018-Fix-memory-leak
+- 0024-Use-icon-themes-in-QPrintPreviewDialog-if-they-exist
+- 0061-Annotate-QMutex-with-TSAN-annotations

--- a/conan_patches/qt/patches/android-19-jar.diff
+++ b/conan_patches/qt/patches/android-19-jar.diff
@@ -1,0 +1,71 @@
+diff --git a/src/android/jar/src/org/qtproject/qt5/android/QtActivityDelegate.java b/src/android/jar/src/org/qtproject/qt5/android/QtActivityDelegate.java
+index 1218164..a5bd6c5 100644
+--- a/src/android/jar/src/org/qtproject/qt5/android/QtActivityDelegate.java
++++ b/src/android/jar/src/org/qtproject/qt5/android/QtActivityDelegate.java
+@@ -847,7 +847,10 @@ public class QtActivityDelegate
+                 m_splashScreenSticky = info.metaData.containsKey("android.app.splash_screen_sticky") && info.metaData.getBoolean("android.app.splash_screen_sticky");
+                 int id = info.metaData.getInt(splashScreenKey);
+                 m_splashScreen = new ImageView(m_activity);
+-                m_splashScreen.setImageDrawable(m_activity.getResources().getDrawable(id, m_activity.getTheme()));
++                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
++                    m_splashScreen.setImageDrawable(m_activity.getResources().getDrawable(id, m_activity.getTheme()));
++                else
++                    m_splashScreen.setImageDrawable(m_activity.getResources().getDrawable(id));
+                 m_splashScreen.setScaleType(ImageView.ScaleType.FIT_XY);
+                 m_splashScreen.setLayoutParams(new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+                 m_layout.addView(m_splashScreen);
+@@ -1293,7 +1296,10 @@ public class QtActivityDelegate
+             if (attr.type >= TypedValue.TYPE_FIRST_COLOR_INT && attr.type <= TypedValue.TYPE_LAST_COLOR_INT) {
+                 m_activity.getWindow().setBackgroundDrawable(new ColorDrawable(attr.data));
+             } else {
+-                m_activity.getWindow().setBackgroundDrawable(m_activity.getResources().getDrawable(attr.resourceId, m_activity.getTheme()));
++                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
++                    m_activity.getWindow().setBackgroundDrawable(m_activity.getResources().getDrawable(attr.resourceId, m_activity.getTheme()));
++                else
++                    m_activity.getWindow().setBackgroundDrawable(m_activity.getResources().getDrawable(attr.resourceId));
+             }
+             if (m_dummyView != null) {
+                 m_layout.removeView(m_dummyView);
+diff --git a/src/android/jar/src/org/qtproject/qt5/android/QtMessageDialogHelper.java b/src/android/jar/src/org/qtproject/qt5/android/QtMessageDialogHelper.java
+index e84c5d7..a3bbff4 100644
+--- a/src/android/jar/src/org/qtproject/qt5/android/QtMessageDialogHelper.java
++++ b/src/android/jar/src/org/qtproject/qt5/android/QtMessageDialogHelper.java
+@@ -109,8 +109,7 @@ public class QtMessageDialogHelper
+         try {
+             TypedValue typedValue = new TypedValue();
+             m_theme.resolveAttribute(android.R.attr.alertDialogIcon, typedValue, true);
+-            return m_activity.getResources().getDrawable(typedValue.resourceId,
+-                                                         m_activity.getTheme());
++            return m_activity.getResources().getDrawable(typedValue.resourceId);
+         } catch (Exception e) {
+             e.printStackTrace();
+         }
+@@ -120,8 +119,7 @@ public class QtMessageDialogHelper
+         {
+             case 1: // Information
+                 try {
+-                    return m_activity.getResources().getDrawable(android.R.drawable.ic_dialog_info,
+-                                                                 m_activity.getTheme());
++                    return m_activity.getResources().getDrawable(android.R.drawable.ic_dialog_info);
+                 } catch (Exception e) {
+                     e.printStackTrace();
+                 }
+@@ -135,16 +133,14 @@ public class QtMessageDialogHelper
+ //                break;
+             case 3: // Critical
+                 try {
+-                    return m_activity.getResources().getDrawable(android.R.drawable.ic_dialog_alert,
+-                                                                 m_activity.getTheme());
++                    return m_activity.getResources().getDrawable(android.R.drawable.ic_dialog_alert);
+                 } catch (Exception e) {
+                     e.printStackTrace();
+                 }
+                 break;
+             case 4: // Question
+                 try {
+-                    return m_activity.getResources().getDrawable(android.R.drawable.ic_menu_help,
+-                                                                 m_activity.getTheme());
++                    return m_activity.getResources().getDrawable(android.R.drawable.ic_menu_help);
+                 } catch (Exception e) {
+                     e.printStackTrace();
+                 }

--- a/conan_patches/qt/patches/android-19-java.diff
+++ b/conan_patches/qt/patches/android-19-java.diff
@@ -1,0 +1,13 @@
+diff --git a/src/android/java/src/org/qtproject/qt5/android/bindings/QtLoader.java b/src/android/java/src/org/qtproject/qt5/android/bindings/QtLoader.java
+index 1e72aa3..982d060 100644
+--- a/src/android/java/src/org/qtproject/qt5/android/bindings/QtLoader.java
++++ b/src/android/java/src/org/qtproject/qt5/android/bindings/QtLoader.java
+@@ -182,7 +182,7 @@ public abstract class QtLoader {
+     }
+     // Implement in subclass
+ 
+-    private final List<String> supportedAbis = Arrays.asList(Build.SUPPORTED_ABIS);
++    private final List<String> supportedAbis = Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP ? Arrays.asList(Build.SUPPORTED_ABIS) : List.of(Build.CPU_ABI);
+     private String preferredAbi = null;
+ 
+     private ArrayList<String> prefferedAbiLibs(String []libs)


### PR DESCRIPTION
- patches for Android < 21 (basically just 19 / 4.4, 32-bit ARM only) were forgotten
- fixes consuming prebuilt dependencies on macOS Intel, see https://github.com/conan-io/conan-center-index/pull/28251
- adds info about KDE patches