### PR TITLE
ffmpeg adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,4 @@ Current flow to update dependencies:
   - https://docs.conan.io/2/reference/conan_server.html (not recommended by Conan)
   - https://jfrog.com/
 
-- Rebuild ffmpeg with libdav1d and av1 support enabled. Needs investigation as to why dav1d fails to build on mingw and on android.
-
 - Run CI with full package rebuild on schedule (weekly? monthly?) to detect any regressions or breaking changes in CI or in used recipes

--- a/conan_profiles/base/common
+++ b/conan_profiles/base/common
@@ -66,10 +66,8 @@ ffmpeg/*:disable_all_parsers=True
 ffmpeg/*:disable_all_protocols=True
 
 ffmpeg/*:with_freetype=False
-ffmpeg/*:with_libalsa=False
 ffmpeg/*:with_libaom=False
 ffmpeg/*:with_libdav1d=True
-ffmpeg/*:with_libdrm=False
 ffmpeg/*:with_libfdk_aac=False
 ffmpeg/*:with_libiconv=False
 ffmpeg/*:with_libmp3lame=False
@@ -82,15 +80,9 @@ ffmpeg/*:with_lzma=True
 ffmpeg/*:with_openh264=False
 ffmpeg/*:with_openjpeg=False
 ffmpeg/*:with_programs=False
-ffmpeg/*:with_pulse=False
 ffmpeg/*:with_sdl=False
 ffmpeg/*:with_ssl=False
-ffmpeg/*:with_vaapi=False
-ffmpeg/*:with_vdpau=False
 ffmpeg/*:with_vorbis=False
-ffmpeg/*:with_vulkan=False
-ffmpeg/*:with_xcb=False
-ffmpeg/*:with_xlib=False
 
 # We want following options supported:
 # H3:SoD - .bik and .smk

--- a/conan_profiles/base/common
+++ b/conan_profiles/base/common
@@ -65,10 +65,11 @@ ffmpeg/*:disable_all_muxers=True
 ffmpeg/*:disable_all_parsers=True
 ffmpeg/*:disable_all_protocols=True
 
-ffmpeg/*:with_asm=False
 ffmpeg/*:with_freetype=False
+ffmpeg/*:with_libalsa=False
 ffmpeg/*:with_libaom=False
-ffmpeg/*:with_libdav1d=False
+ffmpeg/*:with_libdav1d=True
+ffmpeg/*:with_libdrm=False
 ffmpeg/*:with_libfdk_aac=False
 ffmpeg/*:with_libiconv=False
 ffmpeg/*:with_libmp3lame=False
@@ -81,19 +82,25 @@ ffmpeg/*:with_lzma=True
 ffmpeg/*:with_openh264=False
 ffmpeg/*:with_openjpeg=False
 ffmpeg/*:with_programs=False
+ffmpeg/*:with_pulse=False
 ffmpeg/*:with_sdl=False
 ffmpeg/*:with_ssl=False
+ffmpeg/*:with_vaapi=False
+ffmpeg/*:with_vdpau=False
 ffmpeg/*:with_vorbis=False
+ffmpeg/*:with_vulkan=False
+ffmpeg/*:with_xcb=False
+ffmpeg/*:with_xlib=False
 
 # We want following options supported:
 # H3:SoD - .bik and .smk
 # H3:HD  -  ogg container / theora video / vorbis sound (not supported by VCMI at the moment, but might be supported in future)
-# and for mods - webm container / vp8 or vp9 video / opus sound
-# TODO: add av1 support for mods (requires enabling libdav1d)
+# and for mods - webm container / vp8, vp9 or av1 video / vorbis or opus sound
 {% set ffDecoders = [
     'bink',
     'binkaudio_dct',
     'binkaudio_rdft',
+    'libdav1d',
     'opus',
     'smackaud',
     'smacker',
@@ -107,9 +114,10 @@ ffmpeg/*:with_vorbis=False
     'binka',
     'ogg',
     'smacker',
-    'webm_dash_manifest',
+    'matroska',
 ] %}
 {% set ffParsers = [
+    'av1',
     'opus',
     'vorbis',
     'vp8',

--- a/conan_profiles/base/linux
+++ b/conan_profiles/base/linux
@@ -14,12 +14,12 @@ os=Linux
 [options]
 qt/*:with_freetype=True
 
-# fixing wayland-scanner not finding libiconv
-libiconv/*:shared=False
+wayland/*:shared=True
+xkbcommon/*:shared=True
 
 [replace_requires]
 # conflict with qt (xkbcommon 1.5.0)
-xkbcommon/*:xkbcommon/1.6.0
+xkbcommon/*: xkbcommon/1.6.0
 
 [conf]
 tools.system.package_manager:mode=install

--- a/conan_profiles/base/linux
+++ b/conan_profiles/base/linux
@@ -14,15 +14,6 @@ os=Linux
 [options]
 qt/*:with_freetype=True
 
-ffmpeg/*:with_vaapi=False
-ffmpeg/*:with_vdpau=False
-ffmpeg/*:with_vulkan=False
-ffmpeg/*:with_xcb=False
-ffmpeg/*:with_libalsa=False
-ffmpeg/*:with_pulse=False
-ffmpeg/*:with_xlib=False
-ffmpeg/*:with_libdrm=False
-
 # fixing wayland-scanner not finding libiconv
 libiconv/*:shared=False
 

--- a/conan_profiles/base/linux
+++ b/conan_profiles/base/linux
@@ -14,6 +14,15 @@ os=Linux
 [options]
 qt/*:with_freetype=True
 
+ffmpeg/*:with_libalsa=False
+ffmpeg/*:with_libdrm=False
+ffmpeg/*:with_pulse=False
+ffmpeg/*:with_vaapi=False
+ffmpeg/*:with_vdpau=False
+ffmpeg/*:with_vulkan=False
+ffmpeg/*:with_xcb=False
+ffmpeg/*:with_xlib=False
+
 wayland/*:shared=True
 xkbcommon/*:shared=True
 

--- a/conan_profiles/msvc-x86
+++ b/conan_profiles/msvc-x86
@@ -2,3 +2,11 @@ include(base/msvc-intel)
 
 [settings]
 arch=x86
+
+[options]
+# MSVC link.exe hangs when creating avcodec-62.dll for x86 targets:
+# the makedef-generated .def file with underscore-prefixed symbols (EXTERN_PREFIX="_")
+# causes extremely slow symbol processing in the linker.
+# x64/arm64 don't have this issue (EXTERN_PREFIX="").
+# Building FFmpeg as static avoids DLL/.def creation entirely.
+ffmpeg/*:shared=False

--- a/conan_profiles/msvc-x86
+++ b/conan_profiles/msvc-x86
@@ -4,9 +4,5 @@ include(base/msvc-intel)
 arch=x86
 
 [options]
-# MSVC link.exe hangs when creating avcodec-62.dll for x86 targets:
-# the makedef-generated .def file with underscore-prefixed symbols (EXTERN_PREFIX="_")
-# causes extremely slow symbol processing in the linker.
-# x64/arm64 don't have this issue (EXTERN_PREFIX="").
-# Building FFmpeg as static avoids DLL/.def creation entirely.
-ffmpeg/*:shared=False
+# Linking never finishes with asm enabled
+ffmpeg/*:with_asm=False


### PR DESCRIPTION
- enable `libdav1d` to support `AV1` and remove comments -> than we support all `webm` codecs now
  - @IvanSavenko `libdav1d` seems to compile fine now
- enable `asm` -> no idea why it was disabled as it may improve performance by using assembler instructions
- ~~move disabled parts from `linux` to `common`~~
- replace `webm_dash_manifest` with `matroska` -> by the informations I've [found](https://ffmpeg.org/ffmpeg-formats.html#matroska) `matroska` is the right demuxer for `webm`
- fix for `wayland-scanner`