### PR TITLE
Dynamic VS support for rebuilding dependencies in CI

### DIFF
--- a/.github/workflows/rebuildDependencies.yml
+++ b/.github/workflows/rebuildDependencies.yml
@@ -93,6 +93,7 @@ jobs:
       run: |
         $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
         $installPath = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationPath
+
         $installer = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe"
         & $installer modify --installPath "$installPath" --add Microsoft.VisualStudio.Component.VC.v142.x86.x64 --quiet --norestart
 
@@ -111,8 +112,17 @@ jobs:
       run: |
         BUILD_ACTION=prepare ./build.sh >> "$GITHUB_ENV"
 
-    - name: Configure MSYS2
+    - name: Configure VS version for Conan (Windows)
       if: ${{ startsWith(matrix.platform, 'windows') }}
+      shell: pwsh
+      run: |
+        $platformToolsPath = Join-Path -Path $env:RUNNER_TEMP -ChildPath platformTools
+        # appends to [conf]
+        Add-Content -Path $platformToolsPath -Value "tools.microsoft.msbuild:vs_version=$env:MSBUILD_VS_VERSION"
+        Write-Host "Configured tools.microsoft.msbuild:vs_version=$env:MSBUILD_VS_VERSION"
+
+    - name: Configure MSYS2
+      if: ${{ startsWith(matrix.platform, 'windows') && matrix.platform != 'windows-arm64' }}
       shell: pwsh
       run: |
         $msysBash = "C:\msys64\usr\bin\bash.exe"
@@ -120,15 +130,11 @@ jobs:
 
         # appends to [conf]
         Add-Content -Path $platformToolsPath -Value @"
-        # Conan expects VS major generation (16/17/18..), not marketing year labels (2019/2022/2026..)
-        tools.microsoft.msbuild:vs_version=$env:MSBUILD_VS_VERSION
         tools.microsoft.bash:path=$msysBash
         tools.microsoft.bash:subsystem=msys2
         "@
 
-        if ($env:BUILD_PLATFORM -ne "windows-arm64") {
-          Invoke-Expression "& $msysBash -l -c 'pacman -S base-devel gcc --noconfirm'"
-        }
+        Invoke-Expression "& $msysBash -l -c 'pacman -S base-devel gcc --noconfirm'"
 
     - name: Install system libs recipes
       run: |

--- a/.github/workflows/rebuildDependencies.yml
+++ b/.github/workflows/rebuildDependencies.yml
@@ -20,29 +20,40 @@ jobs:
           - platform: mac-intel
             os: macos-15
             before_install: macos.sh
+
           - platform: mac-arm
             os: macos-15
             before_install: macos.sh
+
           - platform: ios
             os: macos-15
             before_install: macos.sh
+
           - platform: android-armeabi-v7a
             os: ubuntu-latest
             before_install: android-32.sh
+
           - platform: android-arm64-v8a
             os: ubuntu-latest
+
           - platform: android-x64
             os: ubuntu-latest
+
           - platform: windows-x64
-            os: windows-latest
+            os: windows-2025-vs2026
+
           - platform: windows-x86
-            os: windows-latest
+            os: windows-2025-vs2026
+
           - platform: windows-arm64
             os: windows-11-arm
+
           - platform: linux-x64
             os: ubuntu-24.04
+
           - platform: linux-arm64
             os: ubuntu-24.04-arm
+
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -67,6 +78,25 @@ jobs:
         windowsPerl=$(which -a perl | fgrep Strawberry)
         echo "WINDOWS_PERL_DIR=$(dirname "$windowsPerl")" >> "$GITHUB_ENV"
 
+    - name: Detect Visual Studio version (Windows)
+      if: ${{ startsWith(matrix.platform, 'windows') }}
+      shell: pwsh
+      run: |
+        $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+        $vsInstallationVersion = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationVersion
+        $vsMajor = ($vsInstallationVersion -split '\.')[0]
+        echo "MSBUILD_VS_VERSION=$vsMajor" >> $env:GITHUB_ENV
+
+    - name: Install MSVC v142 toolset (Windows non-ARM)
+      if: ${{ startsWith(matrix.platform, 'windows') && matrix.platform != 'windows-arm64' }}
+      shell: pwsh
+      run: |
+        $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+        $installPath = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationPath
+
+        $installer = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe"
+        & $installer modify --installPath "$installPath" --add Microsoft.VisualStudio.Component.VC.v142.x86.x64 --quiet --norestart
+
     - uses: actions/setup-java@v4
       if: ${{ startsWith(matrix.platform, 'android') }}
       with:
@@ -81,6 +111,14 @@ jobs:
     - name: Prepare platform tools
       run: |
         BUILD_ACTION=prepare ./build.sh >> "$GITHUB_ENV"
+
+    - name: Configure VS version for Conan (Windows)
+      if: ${{ startsWith(matrix.platform, 'windows') }}
+      shell: pwsh
+      run: |
+        $platformToolsPath = Join-Path -Path $env:RUNNER_TEMP -ChildPath platformTools
+        Add-Content -Path $platformToolsPath -Value "tools.microsoft.msbuild:vs_version=$env:MSBUILD_VS_VERSION"
+        Write-Host "Configured tools.microsoft.msbuild:vs_version=$env:MSBUILD_VS_VERSION"
 
     - name: Configure MSYS2
       if: ${{ startsWith(matrix.platform, 'windows') && matrix.platform != 'windows-arm64' }}

--- a/.github/workflows/rebuildDependencies.yml
+++ b/.github/workflows/rebuildDependencies.yml
@@ -93,7 +93,6 @@ jobs:
       run: |
         $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
         $installPath = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationPath
-
         $installer = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\setup.exe"
         & $installer modify --installPath "$installPath" --add Microsoft.VisualStudio.Component.VC.v142.x86.x64 --quiet --norestart
 
@@ -121,7 +120,7 @@ jobs:
         Write-Host "Configured tools.microsoft.msbuild:vs_version=$env:MSBUILD_VS_VERSION"
 
     - name: Configure MSYS2
-      if: ${{ startsWith(matrix.platform, 'windows') && matrix.platform != 'windows-arm64' }}
+      if: ${{ startsWith(matrix.platform, 'windows') }}
       shell: pwsh
       run: |
         $msysBash = "C:\msys64\usr\bin\bash.exe"
@@ -129,11 +128,15 @@ jobs:
 
         # appends to [conf]
         Add-Content -Path $platformToolsPath -Value @"
+        # Conan expects VS major generation (16/17/18..), not marketing year labels (2019/2022/2026..)
+        tools.microsoft.msbuild:vs_version=$env:MSBUILD_VS_VERSION
         tools.microsoft.bash:path=$msysBash
         tools.microsoft.bash:subsystem=msys2
         "@
 
-        Invoke-Expression "& $msysBash -l -c 'pacman -S base-devel gcc --noconfirm'"
+        if ($env:BUILD_PLATFORM -ne "windows-arm64") {
+          Invoke-Expression "& $msysBash -l -c 'pacman -S base-devel gcc --noconfirm'"
+        }
 
     - name: Install system libs recipes
       run: |

--- a/.github/workflows/rebuildDependencies.yml
+++ b/.github/workflows/rebuildDependencies.yml
@@ -111,14 +111,6 @@ jobs:
       run: |
         BUILD_ACTION=prepare ./build.sh >> "$GITHUB_ENV"
 
-    - name: Configure VS version for Conan (Windows)
-      if: ${{ startsWith(matrix.platform, 'windows') }}
-      shell: pwsh
-      run: |
-        $platformToolsPath = Join-Path -Path $env:RUNNER_TEMP -ChildPath platformTools
-        Add-Content -Path $platformToolsPath -Value "tools.microsoft.msbuild:vs_version=$env:MSBUILD_VS_VERSION"
-        Write-Host "Configured tools.microsoft.msbuild:vs_version=$env:MSBUILD_VS_VERSION"
-
     - name: Configure MSYS2
       if: ${{ startsWith(matrix.platform, 'windows') }}
       shell: pwsh

--- a/conan_profiles/base/msvc-intel
+++ b/conan_profiles/base/msvc-intel
@@ -9,10 +9,6 @@ include(msvc)
 compiler.version=192
 compiler.update=9
 
-[conf]
-# VS 2022
-tools.microsoft.msbuild:vs_version=17
-
 {% set _WIN32_WINNT_WIN7 = '0x0601' %}
 {% set NTDDI_WIN7 = '0x06010000' %}
 {{ windows.set_defines(


### PR DESCRIPTION
Windows dependencies no longer require specific VS version. 

1) Windows x64 / x86 builds uses now VS 2026 with v142 toolset
2) Windows ARM64 builds available VS 2022 with v143 toolset. NOTE: VS 2022 will turn into VS 2026 probably soon to as ARM Runner is going to be hosted by GitHub instead of 3rd hosted one

When builds succeed we can continue with added required steps to VCMI build CI.

Builded results should be same as before.