### PR TITLE
Fix missing [conf] for Windows builds

### DIFF
--- a/conan_profiles/base/msvc-intel
+++ b/conan_profiles/base/msvc-intel
@@ -9,6 +9,7 @@ include(msvc)
 compiler.version=192
 compiler.update=9
 
+[conf]
 {% set _WIN32_WINNT_WIN7 = '0x0601' %}
 {% set NTDDI_WIN7 = '0x06010000' %}
 {{ windows.set_defines(


### PR DESCRIPTION
Macros were not propagated correctly as I accidentally removed that line in previous PR