### PR TITLE
MSVC profiles fine-tuning and small pipeline improvement

### DIFF
--- a/.github/workflows/rebuildDependencies.yml
+++ b/.github/workflows/rebuildDependencies.yml
@@ -78,15 +78,6 @@ jobs:
         windowsPerl=$(which -a perl | fgrep Strawberry)
         echo "WINDOWS_PERL_DIR=$(dirname "$windowsPerl")" >> "$GITHUB_ENV"
 
-    - name: Detect Visual Studio version (Windows)
-      if: ${{ startsWith(matrix.platform, 'windows') }}
-      shell: pwsh
-      run: |
-        $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-        $vsInstallationVersion = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationVersion
-        $vsMajor = ($vsInstallationVersion -split '\.')[0]
-        echo "MSBUILD_VS_VERSION=$vsMajor" >> $env:GITHUB_ENV
-
     - name: Install MSVC v142 toolset (Windows non-ARM)
       if: ${{ startsWith(matrix.platform, 'windows') && matrix.platform != 'windows-arm64' }}
       shell: pwsh
@@ -112,14 +103,17 @@ jobs:
       run: |
         BUILD_ACTION=prepare ./build.sh >> "$GITHUB_ENV"
 
-    - name: Configure VS version for Conan (Windows)
+    - name: Configure VS version for Conan
       if: ${{ startsWith(matrix.platform, 'windows') }}
       shell: pwsh
       run: |
+        $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+        $vsInstallationVersion = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationVersion
+        $vsMajor = ($vsInstallationVersion -split '\.')[0]
+
         $platformToolsPath = Join-Path -Path $env:RUNNER_TEMP -ChildPath platformTools
         # appends to [conf]
-        Add-Content -Path $platformToolsPath -Value "tools.microsoft.msbuild:vs_version=$env:MSBUILD_VS_VERSION"
-        Write-Host "Configured tools.microsoft.msbuild:vs_version=$env:MSBUILD_VS_VERSION"
+        Add-Content -Path $platformToolsPath -Value "tools.microsoft.msbuild:vs_version=$vsMajor"
 
     - name: Configure MSYS2
       if: ${{ startsWith(matrix.platform, 'windows') && matrix.platform != 'windows-arm64' }}

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,6 @@ tempDir="${tempDir//\\//}" # for Windows
 scriptDir=$(cd "$(dirname "$0")" && pwd)
 cciRecipePathQt='recipes/qt'
 cciRepoName='conan-center-index'
-conanOptionOrdinaryLuaLib='&:lua_lib=lua'
 conanOptionTargetPreWindows10='&:target_pre_windows10=True'
 if command -v python3 >/dev/null ; then
 	python=python3
@@ -187,7 +186,9 @@ build_recipes_from_cci_pull_requests() {
 	# - https://github.com/conan-io/conan-center-index/pull/28251
 	# - https://github.com/conan-io/conan-center-index/pull/29299
 
-	[[ "${CONAN_OPTIONS:-}" == *"$conanOptionOrdinaryLuaLib"* ]] || buildLuaJit=1
+	if [[ -z "${CONAN_OPTIONS:-}" || "$CONAN_OPTIONS" == *"lua_lib=luajit"* ]]; then
+		buildLuaJit=1
+	fi
 
 	clone_repo "https://github.com/kambala-decapitator/$cciRepoName" cci-fork vcmi \
 		${buildLuaJit:+ recipes/luajit} \
@@ -268,7 +269,7 @@ case "$platform" in
 		;;
 	windows-arm64)
 		CONAN_PROFILES_JSON_ARRAY='["msvc-arm64"]'
-		CONAN_OPTIONS="--options '$conanOptionOrdinaryLuaLib'"
+		CONAN_OPTIONS="--options '&:lua_lib=lua'"
 		;;
 	windows-x64)
 		CONAN_PROFILES_JSON_ARRAY='["msvc-x64"]'

--- a/conan_profiles/base/msvc-intel
+++ b/conan_profiles/base/msvc-intel
@@ -7,7 +7,6 @@ include(msvc)
 # https://learn.microsoft.com/en-us/cpp/overview/compiler-versions
 # v142 / 14.29 / 19.29
 compiler.version=192
-compiler.update=9
 
 [conf]
 {% set _WIN32_WINNT_WIN7 = '0x0601' %}

--- a/conan_profiles/base/msvc-user
+++ b/conan_profiles/base/msvc-user
@@ -1,0 +1,3 @@
+[settings]
+{% set compiler, version, _ = detect_api.detect_default_compiler() %}
+&:compiler.version={{ detect_api.default_compiler_version(compiler, version) }}

--- a/conanfile.py
+++ b/conanfile.py
@@ -124,6 +124,7 @@ class VCMI(ConanFile):
 
         # client
         if self.options.with_ffmpeg:
+            self.requires("opus/[<1.6]") # 1.6 doesn't build for Windows ARM: https://github.com/xiph/opus/pull/478
             self.requires("ffmpeg/[>=4.4]")
 
         if self.options.get_safe("with_discord_presence", False):


### PR DESCRIPTION
1. MSVC profiles are improved:
- `compiler.update` is removed from the Intel ones. Now we use runners that have just v145 toolset by default and the v142 one is installed manually - that one is always v14.29, no need to encode the trailing `9` explicitly any more. Besides, end user (prebuilts consumer) won't have to pass `-s "&:compiler.update=~"` to erase the `compiler.update` setting from our profile (thus not requiring exact match his locally installed toolset).
- added new file `msvc-user` that is meant to be used by end user in conjunction with our profiles like this: `-pr <our profile> -pr dependencies/conan_profiles/base/msvc-user` (order of profiles matters). This new partial profile sets user's MSVC compiler version automatically inferred from environment, just like `conan profile detect` does when creating fresh build profile. Which means user won't have to pass `-s "&:compiler.version=X"` manually and figure out what to set in place of X.

2. Build script fix to be able to pass it `lua_lib=None` so that it doesn't build any Lua lib at all - required to make 32-bit ARM Android build succeed on F-Droid (as currently it's unable to build LuaJIT for 32-bit).

3. Opus library is limited to version < 1.6 because 1.6 doesn't build for Windows ARM, but there is already PR to upstream: https://github.com/xiph/opus/pull/478

4. Small CI improvement by merging 2 steps into one.