### PR TITLE
LuaJIT for Windows ARM64

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -275,7 +275,6 @@ case "$platform" in
 		;;
 	windows-arm64)
 		CONAN_PROFILES_JSON_ARRAY='["msvc-arm64"]'
-		CONAN_OPTIONS="--options '$conanOptionOrdinaryLuaLib'"
 		;;
 	windows-x64)
 		CONAN_PROFILES_JSON_ARRAY='["msvc-x64"]'

--- a/conan_patches/qt/conandata.yml
+++ b/conan_patches/qt/conandata.yml
@@ -1,5 +1,5 @@
 patches:
-  "5.15.16":
+  "5.15.19":
     - "base_path": "qt5/qtbase"
       "patch_file": "patches/android-21-22.diff"
     - "base_path": "qt5/qtbase"

--- a/conanfile.py
+++ b/conanfile.py
@@ -88,6 +88,9 @@ class VCMI(ConanFile):
             # TODO: in Qt 6 this option doesn't exist
             self.options["qt"].qtandroidextras = True
 
+        if self.options.lua_lib == "lua":
+            self.options["lua"].compile_as_cpp = True
+
         if is_msvc(self):
             # required because VCMI uses dynamic runtime
             self.options["boost"].shared = True


### PR DESCRIPTION
- the latest LuaJIT can be built for Windows ARM64, let's use it
- also noticed that Qt is actually built without patches, fixed this